### PR TITLE
fix: failing minimal-versions check for `rust_decimal`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ utf8-width = "0.1"
 
 serde = { version = "1", default-features = false, features = ["alloc"], optional = true }
 rocket = { version = "0.5", optional = true }
-rust_decimal = { version = "1", default-features = false, optional = true }
+rust_decimal = { version = "1.17", default-features = false, optional = true }
 
 [dev-dependencies]
 serde_json = "1"


### PR DESCRIPTION
`rust_decimal` needs to be at least `v1.15` to not produce errors during 

```
cargo minimal-versions check
```

I guess they imtroduced a breaking change back then.  

```
error[E0599]: no associated item named `ZERO` found for struct `rust_decimal::Decimal` in the current scope
  --> src/byte/decimal.rs:27:29
   |
27 |         if size >= Decimal::ZERO {
   |                             ^^^^ associated item not found in `Decimal`

error[E0277]: the trait bound `rust_decimal::Decimal: From<u128>` is not satisfied
  --> src/byte/decimal.rs:73:45
   |
73 |                 _ => match size.checked_mul(Decimal::from(unit.as_bytes_u128())) {
   |                                             ^^^^^^^ the trait `From<u128>` is not implemented for `rust_decimal::Decimal`
   |
   = help: the following other types implement trait `From<T>`:
             <rust_decimal::Decimal as From<i16>>
             <rust_decimal::Decimal as From<i32>>
             <rust_decimal::Decimal as From<i64>>
             <rust_decimal::Decimal as From<i8>>
             <rust_decimal::Decimal as From<isize>>
             <rust_decimal::Decimal as From<u16>>
             <rust_decimal::Decimal as From<u32>>
             <rust_decimal::Decimal as From<u64>>
           and 2 others

error[E0277]: the trait bound `rust_decimal::Decimal: From<u128>` is not satisfied
   --> src/byte/decimal.rs:133:24
    |
133 |         let bytes_vd = Decimal::from(bytes_v);
    |                        ^^^^^^^ the trait `From<u128>` is not implemented for `rust_decimal::Decimal`
    |
    = help: the following other types implement trait `From<T>`:
              <rust_decimal::Decimal as From<i16>>
              <rust_decimal::Decimal as From<i32>>
              <rust_decimal::Decimal as From<i64>>
              <rust_decimal::Decimal as From<i8>>
              <rust_decimal::Decimal as From<isize>>
              <rust_decimal::Decimal as From<u16>>
              <rust_decimal::Decimal as From<u32>>
              <rust_decimal::Decimal as From<u64>>
            and 2 others

error[E0277]: the trait bound `rust_decimal::Decimal: From<u128>` is not satisfied
   --> src/byte/decimal.rs:148:31
    |
148 |                 let unit_vd = Decimal::from(unit_v);
    |                               ^^^^^^^ the trait `From<u128>` is not implemented for `rust_decimal::Decimal`
    |
    = help: the following other types implement trait `From<T>`:
              <rust_decimal::Decimal as From<i16>>
              <rust_decimal::Decimal as From<i32>>
              <rust_decimal::Decimal as From<i64>>
              <rust_decimal::Decimal as From<i8>>
              <rust_decimal::Decimal as From<isize>>
              <rust_decimal::Decimal as From<u16>>
              <rust_decimal::Decimal as From<u32>>
              <rust_decimal::Decimal as From<u64>>
            and 2 others

error[E0599]: no associated item named `TEN` found for struct `rust_decimal::Decimal` in the current scope
  --> src/byte/parse.rs:47:51
   |
47 | ...                   .checked_mul(Decimal::TEN)
   |                                             ^^^ associated item not found in `Decimal`

error[E0599]: no associated item named `ZERO` found for struct `rust_decimal::Decimal` in the current scope
   --> src/common.rs:103:32
    |
103 |     debug_assert!(b > Decimal::ZERO);
    |                                ^^^^ associated item not found in `Decimal`

error[E0277]: the trait bound `rust_decimal::Decimal: From<u128>` is not satisfied
   --> src/common.rs:115:25
    |
115 |             let scale = Decimal::from(10u128.pow(precision as u32));
    |                         ^^^^^^^ the trait `From<u128>` is not implemented for `rust_decimal::Decimal`
    |
    = help: the following other types implement trait `From<T>`:
              <rust_decimal::Decimal as From<i16>>
              <rust_decimal::Decimal as From<i32>>
              <rust_decimal::Decimal as From<i64>>
              <rust_decimal::Decimal as From<i8>>
              <rust_decimal::Decimal as From<isize>>
              <rust_decimal::Decimal as From<u16>>
              <rust_decimal::Decimal as From<u32>>
              <rust_decimal::Decimal as From<u64>>
            and 2 others

Some errors have detailed explanations: E0277, E0599.
For more information about an error, try `rustc --explain E0277`.
warning: `byte-unit` (lib) generated 8 warnings
error: could not compile `byte-unit` (lib) due to 7 previous errors; 8 warnings emitted
error: process didn't exit successfully: `/home/sd/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/cargo check --manifest-path Cargo.toml` (exit status: 101)
error: process didn't exit successfully: `/home/sd/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/cargo hack check` (exit status: 1)
```