### PR TITLE
fix: typos in documentation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ assert_eq!(3100, a.divide(5).unwrap().as_u64());
 
 #### Find Out an Appropriate Unit
 
-The `get_exact_unit` and `get_recoverable_unit` methods is useful if you want to find out a unit that is appropriate for a `Byte` instance.
+The `get_exact_unit` and `get_recoverable_unit` methods are useful if you want to find out a unit that is appropriate for a `Byte` instance.
 
 ```rust
 use byte_unit::{Byte, Unit};


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `methods is useful` to `methods are useful`

Please review the changes and let me know if any additional changes are needed.

